### PR TITLE
Temporarily revert navigation tabs

### DIFF
--- a/app/(pages)/chat/page.tsx
+++ b/app/(pages)/chat/page.tsx
@@ -2,11 +2,12 @@
 
 import React from 'react';
 import { Chat } from '../../components/chat/chat';
+import { WorkPageWrapper } from '../../components/work-page-wrapper';
 
 export default function ChatPage() {
   return (
-    <>
+    <WorkPageWrapper title="Chat">
       <Chat />
-    </>
+    </WorkPageWrapper>
   );
 }

--- a/app/(pages)/chat/page.tsx
+++ b/app/(pages)/chat/page.tsx
@@ -6,7 +6,7 @@ import { WorkPageWrapper } from '../../components/work-page-wrapper';
 
 export default function ChatPage() {
   return (
-    <WorkPageWrapper title="Chat">
+    <WorkPageWrapper title="Chat" animateChildren={false}>
       <Chat />
     </WorkPageWrapper>
   );

--- a/app/api/chat/tools/index.ts
+++ b/app/api/chat/tools/index.ts
@@ -22,6 +22,10 @@ export const tools: ToolSet = {
     }),
     execute: async ({ to }) => {
       switch (to) {
+        case 'Chat':
+          return { title: 'AI Chat', url: 'https://ambrosino.io/chat', type: 'html' };
+        case 'About':
+          return { title: 'Site info', url: 'https://ambrosino.io/site', type: 'html' };
         case 'Resume':
           return { title: 'Resume', url: 'https://ambrosino.io/resume.pdf', type: 'pdf' };
         case 'LinkedIn':

--- a/app/components/navigation.tsx
+++ b/app/components/navigation.tsx
@@ -1,5 +1,8 @@
 'use client';
 
+// Temporarily disabled until performance issues are resolved. The component
+// remains in the codebase for future optimization efforts.
+
 import { AnimatePresence, motion } from 'motion/react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';

--- a/app/components/social-link.tsx
+++ b/app/components/social-link.tsx
@@ -15,7 +15,7 @@ export const SocialLink = ({
   text,
   label,
   className,
-  target = '_blank',
+  target,
 }: {
   href: string;
   icon: ReactNode;
@@ -24,11 +24,14 @@ export const SocialLink = ({
   className?: string;
   target?: string;
 }) => {
+  const isExternal = /^https?:\/\//.test(href);
+  const linkTarget = target ?? (isExternal ? '_blank' : undefined);
+
   return (
     <div className={cn(className)}>
       <Tooltip>
         <TooltipTrigger asChild>
-          <Link target={target} className={cn(_cns.button)} href={href}>
+          <Link target={linkTarget} className={cn(_cns.button)} href={href}>
             {icon}
             {label && <span className={cn(_cns.text, 'text-xs')}>{label}</span>}
           </Link>

--- a/app/components/work-page-wrapper.tsx
+++ b/app/components/work-page-wrapper.tsx
@@ -1,8 +1,19 @@
 'use client';
 
 import React, { useEffect, useRef, useState } from 'react';
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from '@/app/components/ui/breadcrumb';
 import type { WorkExperienceRole } from '@/data/work';
+import { IconChevronLeft } from '@tabler/icons-react';
 import AnimateIn from './animate-in';
+import { LinkButton } from './social-link';
+import { cn } from './ui/utils';
 import { Role } from './work-row';
 
 interface WorkPageWrapperProps {
@@ -45,7 +56,37 @@ export function WorkPageWrapper({ title, children, description, parent, roles }:
 
   return (
     <>
-      <article className="z-0 mt-10 flex flex-col items-center px-[var(--padding-pageMargin)] py-[calc(var(--padding-pageMargin)*2)] text-[16px]">
+      <div className="p-pageMargin align-stretch from-background/100 via-background/75 group/nav top-pageMargin sticky top-0 z-50 mx-auto grid translate-z-0 grid-cols-[1fr_auto_1fr] items-center bg-gradient-to-b transition-colors duration-1000 hover:duration-250 md:p-[max(var(--padding-pageMargin),5vh)]">
+        <div className="sm:-ml-1.5">
+          <LinkButton href="/" className="rounded-full" icon={<IconChevronLeft className="iconSize" />} label="Home" />
+        </div>
+        <AnimateIn idx={0} className={`col-span-1 flex justify-center transition-opacity duration-300`}>
+          <Breadcrumb>
+            <BreadcrumbList>
+              {parent && (
+                <>
+                  <BreadcrumbItem>
+                    <BreadcrumbLink href="/">{parent}</BreadcrumbLink>
+                  </BreadcrumbItem>
+                  <BreadcrumbSeparator />
+                </>
+              )}
+
+              <BreadcrumbItem
+                className={cn(
+                  showBreadcrumb ? 'opacity-100' : 'pointer-events-none opacity-10',
+                  'transition-all duration-300',
+                )}
+              >
+                <BreadcrumbPage>{title}</BreadcrumbPage>
+              </BreadcrumbItem>
+            </BreadcrumbList>
+          </Breadcrumb>
+        </AnimateIn>
+        <div className="col-span-1"> </div>
+      </div>
+
+      <article className="z-0 flex flex-col items-center px-[var(--padding-pageMargin)] pb-[calc(var(--padding-pageMargin)*2)] text-[16px]">
         {description && (
           <AnimateIn idx={0} className="mx-auto flex w-full max-w-xl flex-col items-center pt-[5vh] pb-[5vh]">
             <h1 ref={titleRef} className="text-center leading-tight font-medium tracking-tight text-balance">

--- a/app/components/work-page-wrapper.tsx
+++ b/app/components/work-page-wrapper.tsx
@@ -22,10 +22,23 @@ interface WorkPageWrapperProps {
   description?: string;
   parent?: string;
   roles?: Array<WorkExperienceRole>;
+  /**
+   * Disable child entrance animation. Useful when the
+   * page contains fixed-position elements like the chat
+   * input that should remain attached to the viewport.
+   */
+  animateChildren?: boolean;
 }
 
 /** @todo extract toolbar, share with chat page */
-export function WorkPageWrapper({ title, children, description, parent, roles }: WorkPageWrapperProps) {
+export function WorkPageWrapper({
+  title,
+  children,
+  description,
+  parent,
+  roles,
+  animateChildren = true,
+}: WorkPageWrapperProps) {
   const [showBreadcrumb, setShowBreadcrumb] = useState(false);
   const titleRef = useRef<HTMLHeadingElement>(null);
 
@@ -106,9 +119,13 @@ export function WorkPageWrapper({ title, children, description, parent, roles }:
             )}
           </AnimateIn>
         )}
-        <AnimateIn idx={1} className="mx-auto w-full max-w-2xl justify-center">
-          {children}
-        </AnimateIn>
+        {animateChildren ? (
+          <AnimateIn idx={1} className="mx-auto w-full max-w-2xl justify-center">
+            {children}
+          </AnimateIn>
+        ) : (
+          <div className="mx-auto w-full max-w-2xl justify-center">{children}</div>
+        )}
       </article>
     </>
   );

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,11 +3,9 @@ import './globals.css';
 import type { Metadata, Viewport } from 'next';
 import { Geist_Mono, Newsreader } from 'next/font/google';
 import localFont from 'next/font/local';
-import React, { Suspense } from 'react';
+import React from 'react';
 import { ThemeProvider } from '@/app/components/theme-provider';
 import { Toaster } from '@/app/components/ui/sonner';
-import { Navigation } from './components/navigation';
-import { LayoutInner } from './layout-inner';
 
 const _sans = localFont({
   src: './assets/font/sohne.woff2',
@@ -70,17 +68,11 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" suppressHydrationWarning>
-      <body
-        className={`overflow-hidden ${_sans.className} ${_serif.variable} ${geistMono.variable} bg-background antialiased`}
-      >
+      <body className={`${_sans.className} ${_serif.variable} ${geistMono.variable} bg-background antialiased`}>
         <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
-          <Suspense key="layout-inner">
-            <Navigation />
-
-            <LayoutInner>
-              <main>{children}</main>
-            </LayoutInner>
-          </Suspense>
+          <main className="flex min-h-screen justify-center">
+            <div className="w-full">{children}</div>
+          </main>
         </ThemeProvider>
         <Toaster />
       </body>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,6 +6,7 @@ import localFont from 'next/font/local';
 import React from 'react';
 import { ThemeProvider } from '@/app/components/theme-provider';
 import { Toaster } from '@/app/components/ui/sonner';
+import { LayoutInner } from './layout-inner';
 
 const _sans = localFont({
   src: './assets/font/sohne.woff2',
@@ -68,11 +69,11 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" suppressHydrationWarning>
-      <body className={`${_sans.className} ${_serif.variable} ${geistMono.variable} bg-background antialiased`}>
+      <body className={`overflow-hidden ${_sans.className} ${_serif.variable} ${geistMono.variable} bg-background antialiased`}>
         <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
-          <main className="flex min-h-screen justify-center">
-            <div className="w-full">{children}</div>
-          </main>
+          <LayoutInner>
+            <main>{children}</main>
+          </LayoutInner>
         </ThemeProvider>
         <Toaster />
       </body>

--- a/data/links.ts
+++ b/data/links.ts
@@ -3,12 +3,20 @@ import {
   IconBrandGithub,
   IconBrandLine,
   IconBrandLinkedin,
+  IconInfoCircle,
   IconBrandOpenai,
   IconBrandX,
   IconFileTypePdf,
 } from '@tabler/icons-react';
 
-export type SocialLinkKey = 'Chat' | 'Resume' | 'LinkedIn' | 'GitHub' | 'X' | 'Dribbble';
+export type SocialLinkKey =
+  | 'Chat'
+  | 'About'
+  | 'Resume'
+  | 'LinkedIn'
+  | 'GitHub'
+  | 'X'
+  | 'Dribbble';
 
 export type SocialLinkType = {
   key: SocialLinkKey;
@@ -25,6 +33,18 @@ export const primaryLinks: Array<SocialLinkType> = [
     label: 'PDF',
     icon: IconFileTypePdf,
     href: '/resume.pdf',
+  },
+  {
+    key: 'About',
+    text: 'Site info',
+    icon: IconInfoCircle,
+    href: '/site',
+  },
+  {
+    key: 'Chat',
+    text: 'AI Chat',
+    icon: IconBrandLine,
+    href: '/chat',
   },
 ];
 


### PR DESCRIPTION
## Summary
- restore previous layout without the Navigation component
- note that Navigation is disabled for performance
- add Chat and About links back into primary footer links
- support Chat and About in chat API tools
- wrap `/chat` page in WorkPageWrapper and restore original wrapper behavior

## Testing
- `pnpm lint`
- `pnpm test:run`


------
https://chatgpt.com/codex/tasks/task_e_688743a671ec8327a830e7249ff243c5