### PR TITLE
Update site mention and Safari fades

### DIFF
--- a/app/(pages)/chat/page.tsx
+++ b/app/(pages)/chat/page.tsx
@@ -8,7 +8,7 @@ import { IconChevronLeft } from '@tabler/icons-react';
 export default function ChatPage() {
   return (
     <>
-      <div className="p-pageMargin align-stretch from-background/100 via-background/75 group/nav top-pageMargin sticky top-0 z-50 mx-auto grid translate-z-0 grid-cols-[1fr_auto_1fr] items-center bg-gradient-to-b transition-colors duration-1000 hover:duration-250 md:p-[max(var(--padding-pageMargin),5vh)]">
+      <div className="bg-surface-fade-top p-pageMargin align-stretch group/nav top-pageMargin sticky top-0 z-50 mx-auto grid translate-z-0 grid-cols-[1fr_auto_1fr] items-center transition-colors duration-1000 hover:duration-250 md:p-[max(var(--padding-pageMargin),5vh)]">
         <div className="sm:-ml-1.5">
           <LinkButton href="/" className="rounded-full" icon={<IconChevronLeft className="iconSize" />} label="Home" />
         </div>

--- a/app/(pages)/page.tsx
+++ b/app/(pages)/page.tsx
@@ -73,7 +73,7 @@ export default function HomePage() {
 
         <AnimateIn
           idx={3}
-          className="from-background/0 to-background/100 via-background/90 sticky bottom-0 -mx-1.5 flex items-center justify-around gap-6 bg-gradient-to-b pt-[calc(var(--padding-pageMargin)*1.5)] pb-[calc(var(--padding-pageMargin)/1.5)] md:justify-between md:gap-12"
+          className="bg-surface-fade-bottom sticky bottom-0 -mx-1.5 flex items-center justify-around gap-6 pt-[calc(var(--padding-pageMargin)*1.5)] pb-[calc(var(--padding-pageMargin)/1.5)] md:justify-between md:gap-12"
         >
           <div className="flex items-center justify-between gap-3">
             {socialLinks.map((link) => (

--- a/app/api/chat/system-prompt.ts
+++ b/app/api/chat/system-prompt.ts
@@ -31,7 +31,7 @@ Your job is to help visitors quickly understand Andrew’s background, skills, o
 	•	Location: now Massachusetts, USA (Eastern Time), soon San Francisco Bay Area, CA.
 	•	Born: 1992
 	•	Roles:
-	•	Member of Technical Staff @ OpenAI, working on Codex and developer tooling – starting July 29 2025
+	•	Member of Technical Staff @ OpenAI, leading the Codex app and working on developer tooling – starting July 29 2025
 	•	2023 - July 25 2025: Head of Product @ Noyo (health-tech API platform) – also Head of Frontend Engineering & Product Design
 	•	2016-23: Founder / CTO / CPO / President @ Catch (YC W19, acquired)
 	•	Early career at Microsoft, Upthere, MITRE
@@ -85,14 +85,14 @@ ${Object.values(tools)
 # About Andrew
 You have access to:
 - Andrew's resume (via the getResume tool)
-- His work experience including current role at OpenAI as Member of Technical Staff on Codex and applied AI developer tooling (not model research)
+- His work experience including current role at OpenAI as Member of Technical Staff leading the Codex app and working on applied AI developer tooling (not model research)
 - Previous roles including Head of Product at Noyo and Founder of Catch (YC W19)
 - Projects he's worked on including AI products, design systems, and technical implementations
 - His licenses including Investment Advisor Representative (FINRA/SEC) and Insurance Agent
 - Public mentions and achievements
 
 ## Key Background
-- Currently Member of Technical Staff at OpenAI, working on Codex and developer tools
+- Currently Member of Technical Staff at OpenAI, leading the Codex app and working on developer tools
 - Recent public coverage quotes Andrew on Codex and describes his work leading Codex app development
 - Previously founded Catch (YC W19), a fintech company that provided benefits for freelancers (sold the company)
 - Led product and frontend at Noyo, building AI-powered benefits infrastructure

--- a/app/api/chat/system-prompt.ts
+++ b/app/api/chat/system-prompt.ts
@@ -31,7 +31,7 @@ Your job is to help visitors quickly understand Andrew’s background, skills, o
 	•	Location: now Massachusetts, USA (Eastern Time), soon San Francisco Bay Area, CA.
 	•	Born: 1992
 	•	Roles:
-	•	Member of Technical Staff @ OpenAI – starting July 29 2025
+	•	Member of Technical Staff @ OpenAI, working on Codex and developer tooling – starting July 29 2025
 	•	2023 - July 25 2025: Head of Product @ Noyo (health-tech API platform) – also Head of Frontend Engineering & Product Design
 	•	2016-23: Founder / CTO / CPO / President @ Catch (YC W19, acquired)
 	•	Early career at Microsoft, Upthere, MITRE
@@ -85,14 +85,15 @@ ${Object.values(tools)
 # About Andrew
 You have access to:
 - Andrew's resume (via the getResume tool)
-- His work experience including current role at OpenAI as Member of Technical Staff (Applied AI, not model research)
+- His work experience including current role at OpenAI as Member of Technical Staff on Codex and applied AI developer tooling (not model research)
 - Previous roles including Head of Product at Noyo and Founder of Catch (YC W19)
 - Projects he's worked on including AI products, design systems, and technical implementations
 - His licenses including Investment Advisor Representative (FINRA/SEC) and Insurance Agent
 - Public mentions and achievements
 
 ## Key Background
-- Currently Member of Technical Staff at OpenAI
+- Currently Member of Technical Staff at OpenAI, working on Codex and developer tools
+- Recent public coverage quotes Andrew on Codex and describes his work leading Codex app development
 - Previously founded Catch (YC W19), a fintech company that provided benefits for freelancers (sold the company)
 - Led product and frontend at Noyo, building AI-powered benefits infrastructure
 - Has worked at companies like MITRE, Microsoft, and Upthere (as KPCB Design Fellow)

--- a/app/components/chat/chat.tsx
+++ b/app/components/chat/chat.tsx
@@ -42,7 +42,7 @@ export function Chat() {
           <div ref={messagesEndRef} />
         </div>
       </div>
-      <div className="from-background/0 to-background p-pageMargin fixed right-0 bottom-0 left-0 mx-auto h-30 max-w-2xl bg-gradient-to-b">
+      <div className="bg-surface-fade-bottom p-pageMargin fixed right-0 bottom-0 left-0 mx-auto h-30 max-w-2xl">
         <AnimateInUp idx={0}>
           <ChatInput
             handleSubmit={(text) => sendMessage({ text: text })}

--- a/app/components/navigation.tsx
+++ b/app/components/navigation.tsx
@@ -176,7 +176,7 @@ export const Navigation = () => {
   return (
     <motion.div
       layoutRoot
-      className="from-background to-background/0 p-pageMargin fixed top-0 right-0 left-0 z-50 flex items-center justify-center bg-gradient-to-b from-0% to-100% pt-[min(12px,calc(var(--padding-pageMargin)*2))] pb-[calc(var(--padding-pageMargin)*2)]"
+      className="bg-surface-fade-top p-pageMargin fixed top-0 right-0 left-0 z-50 flex items-center justify-center pt-[min(12px,calc(var(--padding-pageMargin)*2))] pb-[calc(var(--padding-pageMargin)*2)]"
     >
       <AnimatePresence mode="wait">
         <div className="mx-auto grid w-full max-w-xl grid-cols-[1fr_auto_1fr] items-center">

--- a/app/components/work-page-wrapper.tsx
+++ b/app/components/work-page-wrapper.tsx
@@ -56,7 +56,7 @@ export function WorkPageWrapper({ title, children, description, parent, roles }:
 
   return (
     <>
-      <div className="p-pageMargin align-stretch from-background/100 via-background/75 group/nav top-pageMargin sticky top-0 z-50 mx-auto grid translate-z-0 grid-cols-[1fr_auto_1fr] items-center bg-gradient-to-b transition-colors duration-1000 hover:duration-250 md:p-[max(var(--padding-pageMargin),5vh)]">
+      <div className="bg-surface-fade-top p-pageMargin align-stretch group/nav top-pageMargin sticky top-0 z-50 mx-auto grid translate-z-0 grid-cols-[1fr_auto_1fr] items-center transition-colors duration-1000 hover:duration-250 md:p-[max(var(--padding-pageMargin),5vh)]">
         <div className="sm:-ml-1.5">
           <LinkButton href="/" className="rounded-full" icon={<IconChevronLeft className="iconSize" />} label="Home" />
         </div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -84,6 +84,7 @@
 
 :root {
   --radius: 0.625rem;
+  --background-rgb: 255 255 255;
   --background: oklch(1 0 0);
   --foreground: oklch(0.15 0 0);
   --card: oklch(1 0 0);
@@ -132,6 +133,7 @@
   }
 
 .dark {
+  --background-rgb: 19 19 19;
   --background: oklch(0.145 0 0);
   --foreground: oklch(0.95 0 0);
   --card: oklch(0.205 0 0);
@@ -208,6 +210,22 @@
 }
 
 @layer utilities {
+  .bg-surface-fade-bottom {
+    background-image: linear-gradient(
+      to bottom,
+      rgb(var(--background-rgb) / 0),
+      rgb(var(--background-rgb) / 0.9),
+      rgb(var(--background-rgb) / 1)
+    );
+  }
+  .bg-surface-fade-top {
+    background-image: linear-gradient(
+      to bottom,
+      rgb(var(--background-rgb) / 1),
+      rgb(var(--background-rgb) / 0.75),
+      rgb(var(--background-rgb) / 0)
+    );
+  }
   .blend {
     mix-blend-mode: var(--blend);
   }

--- a/data/mentions.ts
+++ b/data/mentions.ts
@@ -7,6 +7,12 @@ export type Mention = {
 
 export const mentions: Array<Mention> = [
   {
+    title: 'OpenAI drastically updates Codex desktop app',
+    description: 'VentureBeat',
+    url: 'https://venturebeat.com/technology/openai-drastically-updates-codex-desktop-app-to-use-all-other-apps-on-your-computer-generate-images-preview-webpages/',
+    year: '2026',
+  },
+  {
     title: 'Catch takes hold of $12M to provide benefits that aren’t tied to employers',
     description: 'Series A',
     url: 'https://techcrunch.com/2021/07/30/catch-takes-hold-of-12m-to-provide-benefits-that-arent-tied-to-employers/',

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -91,6 +91,7 @@ Worked on developer tools and platforms.
 
 ## Media Mentions
 
+- **VentureBeat**: "OpenAI drastically updates Codex desktop app" (2026)
 - **TechCrunch Series A**: "Catch takes hold of $12M to provide benefits that aren't tied to employers" (2021)
 - **TechCrunch Seed**: "Gig workers need health & benefits — Catch is their safety net" (2019)
 - **Medium**: "macOS: It's time to take the next step" - Early concept work (2016)


### PR DESCRIPTION
## Summary
- Add the VentureBeat Codex desktop app mention to the site and llms.txt.
- Update the chatbot prompt to say Andrew leads the Codex app.
- Replace Safari-sensitive Tailwind page fades with explicit RGB-alpha surface fade utilities.

## Validation
- pnpm lint
- pnpm test:run
- pnpm build

Notes: lint/build still show pre-existing warnings; build also prints the existing OPENAI_API_KEY warning but exits successfully.